### PR TITLE
Enhance chatbot conversation

### DIFF
--- a/src/app/api/openai/route.ts
+++ b/src/app/api/openai/route.ts
@@ -5,10 +5,7 @@ const openai = new OpenAI({
   apiKey: process.env.NEXT_PUBLIC_OPENAI_API_KEY,
 });
 
-const contextMessage = `
-Only reply to the user based off of information found in the resume below. Do not provide any additional information. 
-If the user asks a question that is not answered in the text below, except a greeting like "Hello", reply with "I'm sorry, I cannot provide that information. 
-Try to have a distended tone and not use the exact words of the text below, you can redact the messages yourrself not jsut copying the text."
+const contextMessage = `You are a helpful assistant who answers questions about Martin Pascale using only the information in the resume below. If a question cannot be answered from this resume and it is not a simple greeting, reply with "I'm sorry, I cannot provide that information." Keep responses brief and friendly.
 
 Links:
 <li><a href="https://www.linkedin.com/in/martin-pascale-garcia-370128149/">LinkedIn</a></li>
@@ -80,15 +77,12 @@ The game also features a unique art style that is reminiscent of old CRT TVs.
 `;
 
 export async function POST(request: Request) {
-  const { message } = await request.json();
+  const { messages } = await request.json();
 
   try {
     const stream = await openai.chat.completions.create({
-      model: 'gpt-4o-mini',
-      messages: [
-        { role: 'system', content: contextMessage },
-        { role: 'user', content: message },
-      ],
+      model: 'gpt-4o',
+      messages: [{ role: 'system', content: contextMessage }, ...(messages || [])],
       stream: true,
     });
 

--- a/src/app/components/Chatbot.tsx
+++ b/src/app/components/Chatbot.tsx
@@ -35,7 +35,13 @@ const ChatbotUI = () => {
 
     setLoading(true);
     const userMessage = { role: 'user', content: input };
-    setMessages((prevMessages) => [...prevMessages, userMessage]);
+    const newMessages = [...messages, userMessage];
+    setMessages(newMessages);
+
+    const payload = newMessages.slice(1).map((msg) => ({
+      role: msg.role === 'bot' ? 'assistant' : 'user',
+      content: msg.content,
+    }));
 
     try {
       const response = await fetch('/api/openai', {
@@ -43,7 +49,7 @@ const ChatbotUI = () => {
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ message: input }),
+        body: JSON.stringify({ messages: payload }),
       });
 
       if (!response.ok) {

--- a/src/app/components/Chatbot.tsx
+++ b/src/app/components/Chatbot.tsx
@@ -91,6 +91,12 @@ const ChatbotUI = () => {
           placeholder="Type a message..."
           value={input}
           onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              handleSend();
+            }
+          }}
         />
         <AnimatedButton onClick={handleSend} isLoading={loading}>
           Send

--- a/src/app/lib/OpenAIClient.ts
+++ b/src/app/lib/OpenAIClient.ts
@@ -4,8 +4,7 @@ const openai = new OpenAI({
   apiKey: process.env.NEXT_PUBLIC_OPENAI_API_KEY,
 });
 
-const contextMessage = `
-Only reply to the user with information found in the resume below. Do not provide any additional information.
+const contextMessage = `You are a helpful assistant who answers questions about Martin Pascale using only the information in the resume below. If the resume does not contain the answer and the user is not just greeting you, reply with "I'm sorry, I cannot provide that information." Keep responses brief and friendly.
 
 Persona
 Martin Pascale is a 25 year old senior softare engineer who lives in montevideo uruguay. He has more than 5 years of experience in the field.
@@ -63,15 +62,12 @@ Facultad de Ingenieria UDELAR March 2017 to Nov 2021
 Software Engineering`;
 
 export async function getOpenAIResponseStream(
-  message: string,
+  messages: { role: string; content: string }[],
   onData: (data: string) => void,
 ) {
   const stream = await openai.chat.completions.create({
-    model: 'gpt-4o-mini',
-    messages: [
-      { role: 'user', content: contextMessage },
-      { role: 'user', content: message },
-    ],
+    model: 'gpt-4o',
+    messages: [{ role: 'system', content: contextMessage }, ...messages],
     stream: true,
   });
   for await (const chunk of stream) {

--- a/src/app/lib/OpenAIClient.ts
+++ b/src/app/lib/OpenAIClient.ts
@@ -1,4 +1,5 @@
 import OpenAI from 'openai';
+import type { ChatCompletionMessageParam } from 'openai/resources/chat/completions';
 
 const openai = new OpenAI({
   apiKey: process.env.NEXT_PUBLIC_OPENAI_API_KEY,
@@ -62,7 +63,7 @@ Facultad de Ingenieria UDELAR March 2017 to Nov 2021
 Software Engineering`;
 
 export async function getOpenAIResponseStream(
-  messages: { role: string; content: string }[],
+  messages: ChatCompletionMessageParam[],
   onData: (data: string) => void,
 ) {
   const stream = await openai.chat.completions.create({


### PR DESCRIPTION
## Summary
- use gpt-4o for answering questions
- keep CV data in a new system prompt
- allow conversation history by sending previous messages

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842e1221a38832f944bc98b009a29cd